### PR TITLE
JP-443 When we generate stop_times add also activity

### DIFF
--- a/config/gtfs/schema.ts
+++ b/config/gtfs/schema.ts
@@ -98,6 +98,7 @@ CREATE TABLE stop_times (
   drop_off_type tinyint(1) unsigned DEFAULT NULL,
   shape_dist_traveled varchar(50) DEFAULT NULL,
   timepoint tinyint(1) unsigned DEFAULT NULL,
+  activity varchar(13) DEFAULT NULL,
   PRIMARY KEY (trip_id, stop_sequence),
   KEY arrival_time (arrival_time),
   KEY departure_time (departure_time),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@assertis/dtd2mysql",
-  "version": "6.4.0",
+  "version": "6.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "ts-node ./src/index.ts",
     "prepublishOnly": "tsc -p ./ --outDir dist/ && cp -r config/timetable/data dist/config/timetable/data",
     "gtfs": "NODE_OPTIONS='--max-old-space-size=3000' ts-node ./src/index.ts --gtfs",
+    "gtfs-import": "NODE_OPTIONS='--max-old-space-size=3000' ts-node ./src/index.ts --gtfs-import",
     "gtfs-zip": "NODE_OPTIONS='--max-old-space-size=3000' ts-node ./src/index.ts --gtfs-zip"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assertis/dtd2mysql",
-  "version": "6.4.3",
+  "version": "6.4.4",
   "description": "Command line tool to put the GB rail DTD feed into a MySQL compatible database",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/gtfs/file/StopTime.ts
+++ b/src/gtfs/file/StopTime.ts
@@ -12,6 +12,7 @@ export interface StopTime {
   drop_off_type: 0 | 1 | 2 | 3;
   shape_dist_traveled: null;
   timepoint: 0 | 1;
+  activity: string;
 }
 
 export type Platform = string;

--- a/src/gtfs/native/Association.ts
+++ b/src/gtfs/native/Association.ts
@@ -128,7 +128,8 @@ export class Association implements OverlayRecord {
       assoc.operator,
       assoc.stp,
       assoc.firstClassAvailable,
-      assoc.reservationPossible
+      assoc.reservationPossible,
+      assoc.activity
     )
   }
 

--- a/src/gtfs/native/Schedule.ts
+++ b/src/gtfs/native/Schedule.ts
@@ -23,7 +23,8 @@ export class Schedule implements OverlayRecord {
     public readonly operator: AgencyID | null,
     public readonly stp: STP,
     public readonly firstClassAvailable: boolean,
-    public readonly reservationPossible: boolean
+    public readonly reservationPossible: boolean,
+    public readonly activity: string
   ) {}
 
   public get origin(): CRS {
@@ -52,7 +53,8 @@ export class Schedule implements OverlayRecord {
       this.operator,
       this.stp,
       this.firstClassAvailable,
-      this.reservationPossible
+      this.reservationPossible,
+      this.activity
     );
   }
 

--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -89,7 +89,8 @@ export class ScheduleBuilder {
       row.atoc_code,
       row.stp_indicator,
       row.train_class !== "S",
-      row.reservations !== null
+      row.reservations !== null,
+      row.activity
     );
   }
 
@@ -122,7 +123,8 @@ export class ScheduleBuilder {
       pickup_type: coordinatedDropOff || pickup,
       drop_off_type: coordinatedDropOff || dropOff,
       shape_dist_traveled: null,
-      timepoint: 1
+      timepoint: 1,
+      activity: row.activity
     };
   }
 


### PR DESCRIPTION
For now that's the most efficient way. In future we want to merge `ojp` to `timetable` at least I heard about it from Michał.

That way we're able to handle it for now.