### PR TITLE
JP-397 Missing routes with "replacement bus" mode

### DIFF
--- a/src/cli/OutputGTFSCommand.ts
+++ b/src/cli/OutputGTFSCommand.ts
@@ -20,8 +20,7 @@ export class OutputGTFSCommand implements CLICommand {
   public constructor(
     private readonly repository: CIFRepository,
     private readonly output: GTFSOutput
-  ) {
-  }
+  ) {}
 
   /**
    * Turn the timetable feed into GTFS files

--- a/src/cli/OutputGTFSCommand.ts
+++ b/src/cli/OutputGTFSCommand.ts
@@ -99,11 +99,8 @@ export class OutputGTFSCommand implements CLICommand {
     }
 
     for (const route of Object.values(routes)) {
-      if (route.hasOwnProperty('route_short_name') && route['route_short_name'] === 'SR:ABD->DEE') {
-        console.log('----',route,'-----');
-      }
       routeFile.write(route);
-              }
+    }
 
     trips.end();
     stopTimes.end();
@@ -123,12 +120,6 @@ export class OutputGTFSCommand implements CLICommand {
     const mergedSchedules = <Schedule[]>mergeSchedules(associatedSchedules);
     const schedules = addLateNightServices(mergedSchedules, scheduleResults.idGenerator);
 
-    for (const schedulesKey in schedules) {
-      const schedule = schedules[schedulesKey];
-      // if (schedule.toRoute().route_short_name === "SR:ABD->DEE") {
-      //     console.log('---AS--',schedule.toRoute(),'---AS---');
-      // }
-    }
     return schedules;
   }
 

--- a/src/cli/OutputGTFSCommand.ts
+++ b/src/cli/OutputGTFSCommand.ts
@@ -12,7 +12,7 @@ import {GTFSOutput} from "../gtfs/output/GTFSOutput";
 import * as fs from "fs";
 import {addLateNightServices} from "../gtfs/command/AddLateNightServices";
 import streamToPromise = require("stream-to-promise");
-import {Route} from "../gtfs/file/Route";
+import {Route, RouteID} from "../gtfs/file/Route";
 
 export class OutputGTFSCommand implements CLICommand {
   private baseDir: string;
@@ -84,10 +84,10 @@ export class OutputGTFSCommand implements CLICommand {
     const routes = {};
 
     for (const schedule of schedules) {
-      const route = schedule.toRoute();
-      const routeKey = this.getRouteKey(route);
-      routes[routeKey] = routes[routeKey] || route;
-      const routeId = routes[routeKey].route_id;
+      // const route = schedule.toRoute();
+      // const routeKey = this.getRouteKey(route);
+      // routes[routeKey] = routes[routeKey] || route;
+      const routeId = this.getRoutesFromSchedule(schedule, routes);
       const serviceId = serviceIds[schedule.calendar.id];
 
       trips.write(schedule.toTrip(serviceId, routeId));
@@ -117,6 +117,19 @@ export class OutputGTFSCommand implements CLICommand {
     const schedules = addLateNightServices(mergedSchedules, scheduleResults.idGenerator);
 
     return schedules;
+  }
+
+  /**
+   * Wrap around collecting routes to make this thing testable.
+   * We use javascript feature here with passing object reference as argument
+   * @param schedule
+   * @param routesCollection
+   */
+  public getRoutesFromSchedule(schedule: Schedule, routesCollection: {}): RouteID {
+    const route = schedule.toRoute();
+    const routeKey = this.getRouteKey(route);
+    routesCollection[routeKey] = routesCollection[routeKey] || route
+    return routesCollection[routeKey].route_id;
   }
 
   /**

--- a/src/cli/OutputGTFSCommand.ts
+++ b/src/cli/OutputGTFSCommand.ts
@@ -86,9 +86,6 @@ export class OutputGTFSCommand implements CLICommand {
 
     for (const schedule of schedules) {
       const route = schedule.toRoute();
-      // if (schedule.tuid === "M65832") {
-      //     console.log('---FF--',route,'---FF---');
-      // }
       const routeKey = this.getRouteKey(route);
       routes[routeKey] = routes[routeKey] || route;
       const routeId = routes[routeKey].route_id;

--- a/src/gtfs/repository/CIFRepository.ts
+++ b/src/gtfs/repository/CIFRepository.ts
@@ -105,7 +105,7 @@ export class CIFRepository {
           monday, tuesday, wednesday, thursday, friday, saturday, sunday,
           stp_indicator, location AS crs_code, train_category,
           public_arrival_time, public_departure_time, scheduled_arrival_time, scheduled_departure_time,
-          platform, NULL AS atoc_code, z_stop_time.id AS stop_id, activity, NULL AS reservations, "S" AS train_class 
+          platform, NULL AS atoc_code, z_stop_time.id AS stop_id, activity, NULL AS reservations, "S" AS train_class
         FROM z_schedule
         JOIN z_stop_time ON z_schedule.id = z_stop_time.z_schedule
         WHERE runs_from < CURDATE() + INTERVAL 3 MONTH
@@ -113,7 +113,11 @@ export class CIFRepository {
         ORDER BY stop_id
       `))
     ]);
-
+    scheduleBuilder.results.schedules.forEach(schedule => {
+        if(schedule.tuid === 'M65832') {
+            // console.log('Z BAZY DANYCH', schedule.id, schedule.mode);
+        }
+    });
     return scheduleBuilder.results;
   }
 

--- a/src/gtfs/repository/CIFRepository.ts
+++ b/src/gtfs/repository/CIFRepository.ts
@@ -113,11 +113,7 @@ export class CIFRepository {
         ORDER BY stop_id
       `))
     ]);
-    scheduleBuilder.results.schedules.forEach(schedule => {
-        if(schedule.tuid === 'M65832') {
-            // console.log('Z BAZY DANYCH', schedule.id, schedule.mode);
-        }
-    });
+
     return scheduleBuilder.results;
   }
 

--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -66,6 +66,7 @@ export class ScheduleBuilder {
 
   private createSchedule(row: ScheduleStopTimeRow, stops: StopTime[]): Schedule {
     this.maxId = Math.max(this.maxId, row.id);
+
     return new Schedule(
       row.id,
       stops,

--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -66,9 +66,6 @@ export class ScheduleBuilder {
 
   private createSchedule(row: ScheduleStopTimeRow, stops: StopTime[]): Schedule {
     this.maxId = Math.max(this.maxId, row.id);
-    if(row.train_uid === 'M65832') {
-        // console.log(row.id, row.train_uid, row.train_category, routeTypeIndex[row.train_category]);
-    }
     return new Schedule(
       row.id,
       stops,

--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -66,7 +66,9 @@ export class ScheduleBuilder {
 
   private createSchedule(row: ScheduleStopTimeRow, stops: StopTime[]): Schedule {
     this.maxId = Math.max(this.maxId, row.id);
-
+    if(row.train_uid === 'M65832') {
+        // console.log(row.id, row.train_uid, row.train_category, routeTypeIndex[row.train_category]);
+    }
     return new Schedule(
       row.id,
       stops,

--- a/test/database/MySQLSchema.spec.ts
+++ b/test/database/MySQLSchema.spec.ts
@@ -47,7 +47,7 @@ describe("MySQLSchema", () => {
 
 });
 
-class MockDatabaseConnection implements DatabaseConnection {
+export class MockDatabaseConnection implements DatabaseConnection {
   public readonly queries: string[] = [];
 
   query(sql: string, parameters?: any[]): Promise<any> {

--- a/test/gtfs/command/MergeSchedules.spec.ts
+++ b/test/gtfs/command/MergeSchedules.spec.ts
@@ -36,7 +36,8 @@ export function schedule(id: number,
                          to: string,
                          stp: STP = STP.Overlay,
                          days: Days = ALL_DAYS,
-                         stops: StopTime[] = []): Schedule {
+                         stops: StopTime[] = [],
+                         mode: RouteType = RouteType.Rail): Schedule {
 
   return new Schedule(
     id,
@@ -49,7 +50,7 @@ export function schedule(id: number,
       days,
       {}
     ),
-    RouteType.Rail,
+    mode,
     "LN",
     stp,
     true,

--- a/test/gtfs/command/OutputGTFSCommand.spec.ts
+++ b/test/gtfs/command/OutputGTFSCommand.spec.ts
@@ -1,0 +1,48 @@
+import {STP} from "../../../src/gtfs/native/OverlayRecord";
+import {schedule} from "./MergeSchedules.spec";
+import {RouteType} from "../../../src/gtfs/file/Route";
+import {OutputGTFSCommand} from "../../../src/cli/OutputGTFSCommand";
+import {CIFRepository} from "../../../src/gtfs/repository/CIFRepository";
+import {stationCoordinates} from "../../../config/gtfs/station-coordinates";
+import {MockDatabaseConnection} from "../../database/MySQLSchema.spec";
+import {FileOutput} from "../../../src/gtfs/output/FileOutput";
+import {Days} from "../../../src/gtfs/native/ScheduleCalendar";
+import {stop} from "./ApplyAssociations.spec";
+import * as chai from "chai";
+
+describe("OutputGTFSCommand", () => {
+  const ALL_DAYS: Days = {0: 1, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1};
+
+  it("Will create two routes from two schedules when the only difference is mode", () => {
+
+    const baseSchedules = [
+      schedule(1, "A", "2017-01-01", "2017-01-31", STP.Permanent, ALL_DAYS, [
+        stop(1, "ASH", "00:35"),
+        stop(2, "DOV", "01:00"),
+        stop(3, "SEA", "01:30"),
+      ], RouteType.Rail),
+      schedule(2, "A", "2017-02-01", "2017-02-28", STP.Permanent, ALL_DAYS, [
+        stop(1, "ASH", "00:35"),
+        stop(2, "DOV", "01:00"),
+        stop(3, "SEA", "01:30"),
+      ], RouteType.Gondola),
+    ];
+
+    const outputGTFS = new OutputGTFSCommand(
+      new CIFRepository(
+        new MockDatabaseConnection(),
+        require('mysql2').createPool({}),
+        stationCoordinates
+      ),
+      new FileOutput()
+    );
+    const routes = {};
+    for (const schedule of baseSchedules) {
+      outputGTFS.getRoutesFromSchedule(schedule, routes);
+    }
+
+    chai.expect(routes['LN:ASH->SEA-2'].route_type).to.equal(2);
+    chai.expect(routes['LN:ASH->SEA-6'].route_type).to.equal(6);
+  });
+
+});


### PR DESCRIPTION
I noticed that we overwrite routes no matter what mode is there. 

For this query https://railsmartr.test.assertis.co.uk/fares?origin=8976&destination=9039&adults=1&children=0&outward=2019-03-17-19-00 all routes should have replacement bus mode, but they have train. 

When I investigating this task I noticed that we build two routes based on schedules one with "train" mode and second one with "replacement bus" mode. But as you can see in the code I changed overwriting to take into account mode of schedule.

It solve this issue but I'm not totally sure if it won't cause some different issues so please let me know if you feel that it can break something