### PR TITLE
JP-480 Store activities and activities patterns in ojp database

### DIFF
--- a/config/gtfs/schema.ts
+++ b/config/gtfs/schema.ts
@@ -98,7 +98,7 @@ CREATE TABLE stop_times (
   drop_off_type tinyint(1) unsigned DEFAULT NULL,
   shape_dist_traveled varchar(50) DEFAULT NULL,
   timepoint tinyint(1) unsigned DEFAULT NULL,
-  activity varchar(13) DEFAULT NULL,
+  activity varchar(255) DEFAULT NULL,
   PRIMARY KEY (trip_id, stop_sequence),
   KEY arrival_time (arrival_time),
   KEY departure_time (departure_time),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assertis/dtd2mysql",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "description": "Command line tool to put the GB rail DTD feed into a MySQL compatible database",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/cli/OutputGTFSCommand.ts
+++ b/src/cli/OutputGTFSCommand.ts
@@ -37,8 +37,7 @@ export class OutputGTFSCommand implements CLICommand {
     const transfersP = this.copy(this.repository.getTransfers(), "transfers.txt");
     const stopsP = this.copy(this.repository.getStops(), "stops.txt");
     const agencyP = this.copy(agencies, "agency.txt");
-    let fixedLinksP;
-    // const fixedLinksP = this.copy(this.repository.getFixedLinks(), "links.txt");
+    const fixedLinksP = this.copy(this.repository.getFixedLinks(), "links.txt");
 
     const schedules = this.getSchedules(await associationsP, await scheduleResultsP);
     const [calendars, calendarDates, serviceIds] = createCalendar(schedules);

--- a/src/cli/OutputGTFSCommand.ts
+++ b/src/cli/OutputGTFSCommand.ts
@@ -37,7 +37,8 @@ export class OutputGTFSCommand implements CLICommand {
     const transfersP = this.copy(this.repository.getTransfers(), "transfers.txt");
     const stopsP = this.copy(this.repository.getStops(), "stops.txt");
     const agencyP = this.copy(agencies, "agency.txt");
-    const fixedLinksP = this.copy(this.repository.getFixedLinks(), "links.txt");
+    let fixedLinksP;
+    // const fixedLinksP = this.copy(this.repository.getFixedLinks(), "links.txt");
 
     const schedules = this.getSchedules(await associationsP, await scheduleResultsP);
     const [calendars, calendarDates, serviceIds] = createCalendar(schedules);

--- a/src/gtfs/file/StopTime.ts
+++ b/src/gtfs/file/StopTime.ts
@@ -12,7 +12,25 @@ export interface StopTime {
   drop_off_type: 0 | 1 | 2 | 3;
   shape_dist_traveled: null;
   timepoint: 0 | 1;
-  activity: string;
+  activity: Activity;
 }
 
 export type Platform = string;
+
+export type Activity = string | null;
+
+export enum ActivityPattern {
+  PickUpOnly = "PickUpOnly",
+  SetDownOnly = "SetDownOnly",
+  RequestStop = "RequestStop",
+  Normal = "Normal"
+}
+
+export const ActivityMap = {
+  "TB": ActivityPattern.PickUpOnly, // Train Begins
+  "TF": ActivityPattern.SetDownOnly, // Train finish
+  "D": ActivityPattern.SetDownOnly, // Train stops only to set down passengers
+  "U": ActivityPattern.PickUpOnly, // Train stops only to take up passengers
+  "T": ActivityPattern.Normal, // Train stops to take up and set down passengers
+  "R": ActivityPattern.RequestStop // Train stops when required
+};

--- a/src/gtfs/native/Schedule.ts
+++ b/src/gtfs/native/Schedule.ts
@@ -1,5 +1,5 @@
 
-import {StopTime} from "../file/StopTime";
+import {Activity, StopTime} from "../file/StopTime";
 import {OverlapType, ScheduleCalendar} from "./ScheduleCalendar";
 import {Trip} from "../file/Trip";
 import {Route, RouteType} from "../file/Route";
@@ -24,7 +24,7 @@ export class Schedule implements OverlayRecord {
     public readonly stp: STP,
     public readonly firstClassAvailable: boolean,
     public readonly reservationPossible: boolean,
-    public readonly activity: string
+    public readonly activity: Activity
   ) {}
 
   public get origin(): CRS {

--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -94,7 +94,7 @@ export class ScheduleBuilder {
     );
   }
 
-  private getActivities(activity: string) {
+  public getActivities(activity: string) {
     let activitiesPairs = activity.match(/.{1,2}/g);
     const result:string[] = [];
     if(Array.isArray(activitiesPairs)) {

--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -4,7 +4,7 @@ import {RouteType} from "../file/Route";
 import moment = require("moment");
 import {ScheduleCalendar} from "../native/ScheduleCalendar";
 import {ScheduleStopTimeRow} from "./CIFRepository";
-import {StopTime} from "../file/StopTime";
+import {ActivityMap, StopTime} from "../file/StopTime";
 
 const pickupActivities = ["T ", "TB", "U "];
 const dropOffActivities = ["T ", "TF", "D "];
@@ -94,6 +94,21 @@ export class ScheduleBuilder {
     );
   }
 
+  private getActivities(activity: string) {
+    let activitiesPairs = activity.match(/.{1,2}/g);
+    const result:string[] = [];
+    if(Array.isArray(activitiesPairs)) {
+      activitiesPairs = activitiesPairs.map(a => a.trim());
+      for (const pair of activitiesPairs) {
+        if (ActivityMap.hasOwnProperty(pair)) {
+          result.push(pair);
+          result.push(ActivityMap[pair]);
+        }
+      }
+    }
+    return result.length > 0 ? result.join('-') : null; // Join by sth different than ; or , because we load CSV files to database later
+  }
+
   private createStop(row: ScheduleStopTimeRow, stopId: number, departHour: number): StopTime {
     let arrivalTime, departureTime;
 
@@ -112,6 +127,7 @@ export class ScheduleBuilder {
     const pickup = pickupActivities.find(a => activities.includes(a)) && !activities.includes(notAdvertised) ? 0 : 1;
     const coordinatedDropOff = coordinatedActivity.find(a => activities.includes(a)) ? 3 : 0;
     const dropOff = dropOffActivities.find(a => activities.includes(a)) ? 0 : 1;
+    const activitiesPatterns = row.activity !== null ? this.getActivities(row.activity) : null;
 
     return {
       trip_id: row.id,
@@ -124,7 +140,7 @@ export class ScheduleBuilder {
       drop_off_type: coordinatedDropOff || dropOff,
       shape_dist_traveled: null,
       timepoint: 1,
-      activity: row.activity.trimRight()
+      activity: activitiesPatterns
     };
   }
 

--- a/test/gtfs/repository/ScheduleBuilder.spec.ts
+++ b/test/gtfs/repository/ScheduleBuilder.spec.ts
@@ -1,0 +1,19 @@
+import * as chai from "chai";
+import {ScheduleBuilder} from "../../../src/gtfs/repository/ScheduleBuilder";
+import {ActivityPattern} from "../../../src/gtfs/file/StopTime";
+
+describe("ScheduleBuilder", () => {
+
+  const scheduleBuilder = new ScheduleBuilder();
+
+  it("getActivities will return correct activities", () => {
+
+    chai.expect(scheduleBuilder.getActivities("U K")).to.equal("U-" + ActivityPattern.PickUpOnly);
+    chai.expect(scheduleBuilder.getActivities("F K  U")).to.equal("U-"+ActivityPattern.PickUpOnly);
+    chai.expect(scheduleBuilder.getActivities("TBK")).to.equal("TB-"+ ActivityPattern.PickUpOnly);
+    chai.expect(scheduleBuilder.getActivities("TFK")).to.equal("TF-" + ActivityPattern.SetDownOnly);
+    // K. .. .. R
+    chai.expect(scheduleBuilder.getActivities("K     R")).to.equal("R-" + ActivityPattern.RequestStop);
+
+  });
+});


### PR DESCRIPTION
Storing TF,TB,T and any other activities is not enough.
Because when later we transform TF, TB, T to "PickUpOnly","SetDownOnly","Normal" etc. while running odyssey it takes too much time to run.

So it's better to translate activities codes to activities patterns when we update data and store it translated in ojp database. We still need to store original activities in database also that's why I push TF,TB to this array. 
Later on they are used to check some specific conditions in odyssey (it's faster to do it in a view layer rather than loading calling points layer). And when odyssey finished checking these conditons they are filtered out from a view.