### PR TITLE
Separate cleaning old databases

### DIFF
--- a/config/fares/views.ts
+++ b/config/fares/views.ts
@@ -1,4 +1,4 @@
-const TABLES = [
+export const FARES_TABLES = [
   'advance_ticket',
   'easement_detail',
   'easement_exception',
@@ -68,7 +68,7 @@ const TABLES = [
 
 export const faresView = 'START TRANSACTION;' +
   'CREATE TABLE IF NOT EXISTS nfm64(id INT(6));' + // nfm64 is creted in separate process
-  TABLES.map(j => `
+  FARES_TABLES.map(j => `
   DROP TABLE IF EXISTS {orgdb}.${j};
   CREATE OR REPLACE VIEW {orgdb}.${j} AS SELECT * FROM {dbname}.${j};
   `).join('') +

--- a/config/gtfs/views.ts
+++ b/config/gtfs/views.ts
@@ -1,4 +1,4 @@
-const TABLES = [
+export const GTFS_TABLES = [
   'agency',
   'calendar',
   'calendar_dates',
@@ -12,7 +12,7 @@ const TABLES = [
 ];
 
 export const ojpViews = 'START TRANSACTION;' +
-  TABLES.map(j => `
+  GTFS_TABLES.map(j => `
   DROP TABLE IF EXISTS {orgdb}.${j};
   CREATE OR REPLACE VIEW {orgdb}.${j} AS SELECT * FROM {dbname}.${j};
   `).join('') +

--- a/config/routeing/views.ts
+++ b/config/routeing/views.ts
@@ -1,4 +1,4 @@
-const TABLES = [
+export const ROUTEING_TABLES = [
    'easement',
    'easement_detail',
    'easement_exception',
@@ -24,7 +24,7 @@ const TABLES = [
 ];
 
 export const routeingViews = 'START TRANSACTION;' +
-  TABLES.map(j => `
+  ROUTEING_TABLES.map(j => `
   DROP TABLE IF EXISTS {orgdb}.${j};
   CREATE OR REPLACE VIEW {orgdb}.${j} AS SELECT * FROM {dbname}.${j};
   `).join('') +

--- a/config/timetable/views.ts
+++ b/config/timetable/views.ts
@@ -1,4 +1,4 @@
-const TABLES = [
+export const TIMETABLE_TABLES = [
   'additional_fixed_link',
   'alias',
   'association',
@@ -16,7 +16,7 @@ const TABLES = [
 ];
 
 export const timetableViews = 'START TRANSACTION;' +
-  TABLES.map(j => `
+  TIMETABLE_TABLES.map(j => `
   DROP TABLE IF EXISTS {orgdb}.${j};
   CREATE OR REPLACE VIEW {orgdb}.${j} AS SELECT * FROM {dbname}.${j};
   `).join('') +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assertis/dtd2mysql",
-  "version": "6.7.4",
+  "version": "6.7.5",
   "description": "Command line tool to put the GB rail DTD feed into a MySQL compatible database",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/cli/CleanupDatabasesCommand.ts
+++ b/src/cli/CleanupDatabasesCommand.ts
@@ -11,24 +11,24 @@ export class CleanupDatabasesCommand {
 
   }
 
-  public async run(argv: string[]): Promise<void> {
-    // Check if new views in original database works fine
-    const tables = this.offlineProcessor.getTablesList();
-
-    const checkAlltables = () => {
-      for (const table of tables) {
-        const sql = `SELECT * FROM ${table} LIMIT 1`;
-        try {
-          console.log(`[DEBUG] Run check query for table ${table}`);
-          this.databaseConnection.query(sql);
-        } catch (err) {
-          return false;
-        }
+  private checkAllTables(tables: string[]) {
+    for (const table of tables) {
+      const sql = `SELECT * FROM ${table} LIMIT 1`;
+      try {
+        console.log(`[DEBUG] Run check query for table ${table}`);
+        this.databaseConnection.query(sql);
+      } catch (err) {
+        console.log(`[ERROR] ${err.message}`);
+        return false;
       }
-      return true;
-    };
+    }
+    return true;
+  }
 
-    if (checkAlltables()) {
+  public async run(argv: string[]): Promise<void> {
+    // Check if new views in original database work fine
+    const tables = this.offlineProcessor.getTablesList();
+    if (this.checkAllTables(tables)) {
       console.log('[INFO] Views works fine. Removing outdated databases');
       this.offlineProcessor.removeOutdatedOfflineDatabase();
     }

--- a/src/cli/CleanupDatabasesCommand.ts
+++ b/src/cli/CleanupDatabasesCommand.ts
@@ -1,0 +1,37 @@
+import {OfflineDataProcessor} from "../database/OfflineDataProcessor";
+import {DatabaseConnection} from "../database/DatabaseConnection";
+
+
+export class CleanupDatabasesCommand {
+
+  public constructor(
+      private readonly databaseConnection: DatabaseConnection,
+      private readonly offlineProcessor: OfflineDataProcessor
+  ) {
+
+  }
+
+  public async run(argv: string[]): Promise<void> {
+    // Check if new views in original database works fine
+    const tables = this.offlineProcessor.getTablesList();
+
+    const checkAlltables = () => {
+      for (const table of tables) {
+        const sql = `SELECT * FROM ${table} LIMIT 1`;
+        try {
+          console.log(`[DEBUG] Run check query for table ${table}`);
+          this.databaseConnection.query(sql);
+        } catch (err) {
+          return false;
+        }
+      }
+      return true;
+    };
+
+    if (checkAlltables()) {
+      console.log('[INFO] Views works fine. Removing outdated databases');
+      this.offlineProcessor.removeOutdatedOfflineDatabase();
+    }
+    process.exit(0);
+  }
+}

--- a/src/cli/Container.ts
+++ b/src/cli/Container.ts
@@ -27,6 +27,7 @@ import {
   OfflineDataProcessor,
   temporaryDatabaseNameFactory
 } from "../database/OfflineDataProcessor";
+import {CleanupDatabasesCommand} from "./CleanupDatabasesCommand";
 
 export class Container {
 
@@ -77,10 +78,21 @@ export class Container {
         return this.getDownloadAndProcessIdmsFixedLinksCommand();
       case "--get-idms-group":
         return this.getDownloadAndProcessIdmsGroupCommand();
+      case "--clean-databases":
+        return this.getCleanupDatabasesCommand();
       default:
         return this.getShowHelpCommand();
     }
   }
+
+  @memoize
+  public async getCleanupDatabasesCommand(): Promise<CleanupDatabasesCommand> {
+    return new CleanupDatabasesCommand(
+        this.getDatabaseConnection(),
+        new OfflineDataProcessor(process.env.DATABASE_NAME || "", this.databaseConfiguration)
+    );
+  }
+
 
   @memoize
   public async getFaresImportCommand(): Promise<ImportFeedCommand> {

--- a/src/cli/DownloadAndProcessCommand.ts
+++ b/src/cli/DownloadAndProcessCommand.ts
@@ -27,12 +27,14 @@ export class DownloadAndProcessCommand implements CLICommand {
         console.error(err);
       }
     }
-    const viewsQuery = this.offlineDataProcessor.getViews();
-    if(viewsQuery) {
-      console.log(`[INFO] Applying views SQL to original table.`);
-      await this.db.query(
-        viewsQuery
-      );
+    if(!this.offlineDataProcessor.databaseConfiguration.performOnOriginalDb) {
+      const viewsQuery = this.offlineDataProcessor.getViews();
+      if (viewsQuery) {
+        console.log(`[INFO] Applying views SQL to original table.`);
+        await this.db.query(
+            viewsQuery
+        );
+      }
     }
     return this.process.end();
   }

--- a/src/cli/DownloadAndProcessCommand.ts
+++ b/src/cli/DownloadAndProcessCommand.ts
@@ -27,7 +27,7 @@ export class DownloadAndProcessCommand implements CLICommand {
         console.error(err);
       }
     }
-    if(!this.offlineDataProcessor.databaseConfiguration.performOnOriginalDb) {
+    if(!this.offlineDataProcessor.databaseConfiguration.performWithoutViews) {
       const viewsQuery = this.offlineDataProcessor.getViews();
       if (viewsQuery) {
         console.log(`[INFO] Applying views SQL to original table.`);

--- a/src/cli/GTFSImportCommand.ts
+++ b/src/cli/GTFSImportCommand.ts
@@ -32,9 +32,11 @@ export class GTFSImportCommand implements CLICommand {
     if (!viewsDatabase) {
       throw new Error('Cannot create views in correct because DATABASE_NAME is empty');
     }
-    const ojpViewsSql = this.offlineDataProcessor.getViews();
-    const sqlCommand = `mysql ${credentials} ${viewsDatabase} -e "${ojpViewsSql}"`;
-    execSync(sqlCommand, {cwd: path});
+    if(!this.db.performWithoutViews) {
+      const ojpViewsSql = this.offlineDataProcessor.getViews();
+      const sqlCommand = `mysql ${credentials} ${viewsDatabase} -e "${ojpViewsSql}"`;
+      execSync(sqlCommand, {cwd: path});
+    }
   }
 
 }

--- a/src/cli/ImportFeedCommand.ts
+++ b/src/cli/ImportFeedCommand.ts
@@ -43,12 +43,14 @@ export class ImportFeedCommand implements CLICommand {
   public async run(argv: string[]): Promise<void> {
     try {
       await this.doImport(argv[3]);
-      const viewsQuery = this.offlineDataProcessor.getViews();
-      if(viewsQuery) {
-        console.log(`[INFO] Applying views SQL to original table.`);
-        await this.db.query(
-          viewsQuery
-        );
+      if(!this.offlineDataProcessor.databaseConfiguration.performWithoutViews) {
+        const viewsQuery = this.offlineDataProcessor.getViews();
+        if (viewsQuery) {
+          console.log(`[INFO] Applying views SQL to original table.`);
+          await this.db.query(
+              viewsQuery
+          );
+        }
       }
     }
     catch (err) {

--- a/src/database/DatabaseConnection.ts
+++ b/src/database/DatabaseConnection.ts
@@ -14,4 +14,5 @@ export interface DatabaseConfiguration {
   connectionLimit: number,
   multipleStatements: boolean,
   promise?: any
+  performOnOriginalDb?: boolean
 }

--- a/src/database/DatabaseConnection.ts
+++ b/src/database/DatabaseConnection.ts
@@ -14,5 +14,5 @@ export interface DatabaseConfiguration {
   connectionLimit: number,
   multipleStatements: boolean,
   promise?: any
-  performOnOriginalDb?: boolean
+  performWithoutViews?: boolean
 }


### PR DESCRIPTION
* Move cleaning database to separate command so we are able to run it separately after whole database update.

* Add simple `SELECT` query for each table to check if everything works fine and all required tables exists.
