### PR TITLE
JP-609 Always require S3_KEY,S3_SECRET

### DIFF
--- a/src/cli/Container.ts
+++ b/src/cli/Container.ts
@@ -208,12 +208,7 @@ export class Container {
   }
 
   private async getDownloadIdmsFileCommand(filename: string): Promise<DownloadFileFromS3Command | DownloadFileCommand> {
-    const command = process.env.S3_KEY
-      // Download via S3 API
-      ? new DownloadFileFromS3Command(await this.getS3(), idmsBucket, idmsPrefix + filename, filename)
-      // Download via HTTPS
-      : new DownloadFileCommand(idmsUrl + filename, filename);
-
+    const command = new DownloadFileFromS3Command(await this.getS3(), idmsBucket, idmsPrefix + filename, filename)
     return Promise.resolve(command);
   }
 


### PR DESCRIPTION
We should always use S3_KEY, S3_SECRET when we download data from S3. It's not possible to download the data from ride-data bucket through HTTP because all the data are private there.

I'll add proper environmental variables in odyssey of course.