### PR TITLE
JP-834 Fix buses schedule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assertis/dtd2mysql",
-  "version": "6.8.24",
+  "version": "6.8.25",
   "description": "Command line tool to put the GB rail DTD feed into a MySQL compatible database",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -11,6 +11,7 @@ const dropOffActivities = ["T ", "TF", "D "];
 const coordinatedActivity = ["R "];
 const notAdvertised = "N ";
 
+const busCategories = ["BR", "BS"]; //Bus Replacement and Bus Schedule
 /**
  * This class takes a stream of results and builds a list of Schedules
  */
@@ -67,6 +68,14 @@ export class ScheduleBuilder {
   private createSchedule(row: ScheduleStopTimeRow, stops: StopTime[]): Schedule {
     this.maxId = Math.max(this.maxId, row.id);
 
+    /**
+     * General rule for seating classes
+     * Blank or B - First and standard
+     * S - Standard class only.
+     * For buses in data train_class is blank which causes some issues that 1st class fares are available on buses
+     * which is not true
+     */
+    const firstClassAvailable = busCategories.includes(row.train_category) ? false : row.train_class !== "S";
     return new Schedule(
       row.id,
       stops,
@@ -88,7 +97,7 @@ export class ScheduleBuilder {
       routeTypeIndex.hasOwnProperty(row.train_category) ? routeTypeIndex[row.train_category] : RouteType.Rail,
       row.atoc_code,
       row.stp_indicator,
-      row.train_class !== "S",
+      firstClassAvailable,
       row.reservations !== null,
       row.activity
     );

--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -75,6 +75,7 @@ export class ScheduleBuilder {
      * For buses in data train_class is blank which causes some issues that 1st class fares are available on buses
      * which is not true
      */
+    const mode = routeTypeIndex.hasOwnProperty(row.train_category) ? routeTypeIndex[row.train_category] : RouteType.Rail;
     const firstClassAvailable = busCategories.includes(row.train_category) ? false : row.train_class !== "S";
     return new Schedule(
       row.id,
@@ -94,7 +95,7 @@ export class ScheduleBuilder {
           6: row.saturday
         }
       ),
-      routeTypeIndex.hasOwnProperty(row.train_category) ? routeTypeIndex[row.train_category] : RouteType.Rail,
+      mode,
       row.atoc_code,
       row.stp_indicator,
       firstClassAvailable,


### PR DESCRIPTION
BR - Bus Replacement
BS - Bus Schedule

1st class is not available for buses. ATOC says that rules for seating classes are:

```
Seating classes available:
Blank or B - First and standard
S - Standard class only.
```
But for all BR records in schedules train_class field is Blank :) and because of that we return 1st class tickets for buses.

This change is approved by Alistair Lees