### PR TITLE
JP-838 Action.Update instead of Action.Insert for ZTR Records

### DIFF
--- a/config/timetable/file/ZTR.ts
+++ b/config/timetable/file/ZTR.ts
@@ -105,7 +105,7 @@ const stop = new MultiFormatRecord(
   2,
   [],
   true,
-    RecordAction.Update // JP-838
+  RecordAction.Update // JP-838
 );
 
 

--- a/config/timetable/file/ZTR.ts
+++ b/config/timetable/file/ZTR.ts
@@ -1,4 +1,3 @@
-
 import {RecordWithManualIdentifier} from "../../../src/feed/record/FixedWidthRecord";
 import {TextField, VariableLengthText} from "../../../src/feed/field/TextField";
 import {MultiRecordFile} from "../../../src/feed/file/MultiRecordFile";
@@ -7,6 +6,7 @@ import {ShortDateField} from "../../../src/feed/field/DateField";
 import {ForeignKeyField} from "../../../src/feed/field/ForeignKeyField";
 import {TimeField} from "../../../src/feed/field/TimeField";
 import {MultiFormatRecord} from "../../../src/feed/record/MultiFormatRecord";
+import {RecordAction} from "../../../src/feed/record/Record";
 
 
 const schedule = new RecordWithManualIdentifier(
@@ -98,13 +98,14 @@ const stopRecordTypes = {
 
 const stop = new MultiFormatRecord(
   "z_stop_time",
-  ["z_schedule", "location", "public_departure_time"],
+  ["z_schedule", "location", "public_departure_time", "public_arrival_time", "activity"],
   stopRecordTypes.LI,
   stopRecordTypes,
   0,
   2,
   [],
-  true
+  true,
+    RecordAction.Update
 );
 
 

--- a/config/timetable/file/ZTR.ts
+++ b/config/timetable/file/ZTR.ts
@@ -105,7 +105,7 @@ const stop = new MultiFormatRecord(
   2,
   [],
   true,
-    RecordAction.Update
+    RecordAction.Update // JP-838
 );
 
 

--- a/src/feed/record/MultiFormatRecord.ts
+++ b/src/feed/record/MultiFormatRecord.ts
@@ -1,4 +1,3 @@
-
 import {FieldMap, ParsedRecord, Record, RecordAction} from "./Record";
 
 /**
@@ -14,7 +13,8 @@ export class MultiFormatRecord implements Record {
     private readonly recordIdentifierStart: number,
     private readonly recordIdentifierLength: number,
     public readonly indexes: string[] = [],
-    public readonly orderedInserts: boolean = false
+    public readonly orderedInserts: boolean = false,
+    public readonly action: RecordAction = RecordAction.Insert
   ) {}
 
   /**
@@ -24,13 +24,12 @@ export class MultiFormatRecord implements Record {
     const type = line.substr(this.recordIdentifierStart, this.recordIdentifierLength);
     const record = this.records[type];
     const values = { id: null };
-    const action = RecordAction.Insert;
 
     for (const key in record) {
       values[key] = record[key].extract(line.substr(record[key].position, record[key].length));
     }
 
-    return { action, values, keysValues: values };
+    return { action: this.action, values, keysValues: values };
   }
 
 }


### PR DESCRIPTION
As I noticed in ZTR day to day files we don't have any "DELETE" records for ferries.

Because of that after every data update we have duplicated records in `timetable`.`stop_times` and later on when we created GTFS there was some mess in the `stop_times` data. 

After long investigation I've decided to change it into Update action which in real is `REPLACE INTO` so when the record already exist we should just update the data, if not we'll create it. 

I've tested it on my local machine and it fixed few things with ferries.  