### PR TITLE
JP-918 Do transactional update for timetable and routeing

### DIFF
--- a/config/gtfs/schema.ts
+++ b/config/gtfs/schema.ts
@@ -76,18 +76,6 @@ CREATE TABLE routes (
   PRIMARY KEY (route_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-/*
-DROP TABLE IF EXISTS shapes;
-CREATE TABLE shapes (
-  shape_id smallint(12) unsigned NOT NULL,
-  shape_pt_lat decimal(8,6) NOT NULL,
-  shape_pt_lon decimal(8,6) NOT NULL,
-  shape_pt_sequence tinyint(3) NOT NULL,
-  shape_dist_traveled varchar(50) DEFAULT NULL,
-  PRIMARY KEY (shape_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-*/
-
 DROP TABLE IF EXISTS stop_times;
 CREATE TABLE stop_times (
   trip_id mediumint(12) unsigned NOT NULL,

--- a/config/gtfs/schema.ts
+++ b/config/gtfs/schema.ts
@@ -76,6 +76,7 @@ CREATE TABLE routes (
   PRIMARY KEY (route_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+/*
 DROP TABLE IF EXISTS shapes;
 CREATE TABLE shapes (
   shape_id smallint(12) unsigned NOT NULL,
@@ -85,6 +86,7 @@ CREATE TABLE shapes (
   shape_dist_traveled varchar(50) DEFAULT NULL,
   PRIMARY KEY (shape_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+*/
 
 DROP TABLE IF EXISTS stop_times;
 CREATE TABLE stop_times (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@assertis/dtd2mysql",
-  "version": "6.8.23",
+  "version": "6.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/cli/Container.ts
+++ b/src/cli/Container.ts
@@ -76,12 +76,18 @@ export class Container {
         return this.getDownloadAndProcessCommand(faresPath, this.getFaresImportCommand());
       case "--get-fares-in-transaction":
         return this.getDownloadAndProcessInTransactionCommand(faresPath, this.getFaresImportCommandWithFallback());
+      case "--get-timetable-in-transaction":
+        return this.getDownloadAndProcessInTransactionCommand(timetablePath, this.getTimetableImportCommandWithFallback());
+      case "--get-routeing-in-transaction":
+        return this.getDownloadAndProcessInTransactionCommand(routingPath, this.getRouteingImportCommandWithFallback()  );
       case "--get-timetable":
         return this.getDownloadAndProcessCommand(timetablePath, this.getTimetableImportCommand());
       case "--get-routeing":
         return this.getDownloadAndProcessCommand(routingPath, this.getRouteingImportCommand());
       case "--get-nfm64":
         return this.getDownloadAndProcessNFM64Command();
+      case "--get-nfm64-in-transaction":
+        return this.getDownloadAndProcessInTransactionNFM64Command();
       case "--get-idms-fixed-links":
         return this.getDownloadAndProcessIdmsFixedLinksCommand();
       case "--get-idms-group":
@@ -90,6 +96,10 @@ export class Container {
         return this.getCleanupDatabasesCommand();
       case "--backup-fares":
         return this.getBackupDatabaseCommand('fares');
+      case "--backup-timetable":
+        return this.getBackupDatabaseCommand('timetable');
+      case "--backup-routeing":
+        return this.getBackupDatabaseCommand('routeing');
       case "--check-files-availability":
         return this.getCheckAvailableFilesCommand();
       default:
@@ -164,6 +174,25 @@ export class Container {
   }
 
   @memoize
+  public async getTimetableImportCommandWithFallback(): Promise<ImportFeedTransactionalCommand> {
+    return new ImportFeedTransactionalCommand(
+        await this.getDatabaseConnection(),
+        config.timetable,
+        "/tmp/dtd/timetable/"
+    );
+  }
+
+
+  @memoize
+  public async getRouteingImportCommandWithFallback(): Promise<ImportFeedTransactionalCommand> {
+    return new ImportFeedTransactionalCommand(
+        await this.getDatabaseConnection(),
+        config.routeing,
+        "/tmp/dtd/routeing/"
+    );
+  }
+
+  @memoize
   public async getRouteingImportCommand(): Promise<ImportFeedCommand> {
     return new ImportFeedCommand(
       await this.getDatabaseConnection(),
@@ -178,6 +207,15 @@ export class Container {
       await this.getDatabaseConnection(),
       config.timetable,
       "/tmp/dtd/timetable/"
+    );
+  }
+
+  @memoize
+  public async getNFM64ImportCommandWithFallback(): Promise<ImportFeedTransactionalCommand> {
+    return new ImportFeedTransactionalCommand(
+        await this.getDatabaseConnection(),
+        config.nfm64,
+        "/tmp/dtd/nfm64/"
     );
   }
 
@@ -329,6 +367,15 @@ export class Container {
   }
 
   @memoize
+  private async getDownloadAndProcessInTransactionNFM64Command(): Promise<DownloadAndProcessInTransactionCommand> {
+    return new DownloadAndProcessInTransactionCommand(
+        await this.getDownloadNFM64Command(),
+        await this.getNFM64ImportCommandWithFallback(),
+        await this.getDatabaseConnection()
+    );
+  }
+
+  @memoize
   private async getDownloadAndProcessNFM64Command(): Promise<DownloadAndProcessCommand> {
     return new DownloadAndProcessCommand(
       await this.getDownloadNFM64Command(),
@@ -340,9 +387,9 @@ export class Container {
   @memoize
   private async getDownloadAndProcessIdmsFixedLinksCommand(): Promise<DownloadAndProcessCommand> {
     return new DownloadAndProcessCommand(
-      await this.getDownloadIdmsFixedLinksCommand(),
-      await this.getImportIdmsFixedLinksCommand(),
-      await this.getDatabaseConnection()
+        await this.getDownloadIdmsFixedLinksCommand(),
+        await this.getImportIdmsFixedLinksCommand(),
+        await this.getDatabaseConnection()
     );
   }
 

--- a/src/cli/DownloadAndProcessWithReplaceCommand.ts
+++ b/src/cli/DownloadAndProcessWithReplaceCommand.ts
@@ -1,0 +1,36 @@
+
+import {CLICommand} from "./CLICommand";
+import { ImportFeedCommand } from "./ImportFeedCommand";
+import {DatabaseConnection} from "../database/DatabaseConnection";
+
+export class DownloadAndProcessWithReplaceCommand implements CLICommand {
+
+  constructor(
+    private readonly download: FileProvider,
+    private readonly process: ImportFeedCommand,
+    protected readonly db: DatabaseConnection
+  ) {}
+
+  /**
+   * Download and process the feed in one command
+   */
+  public async run(argv: string[]): Promise<any> {
+    const files = await this.download.run([]);
+
+    for (const filename of files) {
+      try {
+        await this.process.doImport(filename);
+      }
+      catch (err) {
+        console.error(err);
+      }
+    }
+
+    return this.process.end();
+  }
+
+}
+
+export interface FileProvider {
+  run(args: any[]): Promise<string[]>;
+}

--- a/src/cli/OutputGTFSCommand.ts
+++ b/src/cli/OutputGTFSCommand.ts
@@ -64,6 +64,9 @@ export class OutputGTFSCommand implements CLICommand {
    */
   private async copy(results: object[] | Promise<object[]>, filename: string): Promise<void> {
     const rows = await results;
+    if (rows.length === 0) {
+      throw new Error(`OJP update failed for ${filename} file. Files shouldn't be empty`)
+    }
     const output = this.output.open(this.baseDir + filename);
 
     console.log("Writing " + filename);


### PR DESCRIPTION
1) Use `_tmp` tables for data update of timetable and routeing.
2) Do some checks for `ojp` tables they never should be empty. We don't need shapes table it's always empty.

First I want to do transactional data update in odyssey. After that we'll add some sanity checks. 
